### PR TITLE
忽略音频焦点hook

### DIFF
--- a/app/src/main/java/com/suqi8/oshin/features/android/android.kt
+++ b/app/src/main/java/com/suqi8/oshin/features/android/android.kt
@@ -49,6 +49,10 @@ object android {
                     Switch(
                         title = StringResource(R.string.allow_untrusted_touch),
                         key = "AllowUntrustedTouch"
+                    ),
+                    Switch(
+                        title = StringResource(R.string.ignore_audio_focus),
+                        key = "IgnoreAudioFocus"
                     )
                 )
             ),

--- a/app/src/main/java/com/suqi8/oshin/hook/android/IgnoreAudioFocus.kt
+++ b/app/src/main/java/com/suqi8/oshin/hook/android/IgnoreAudioFocus.kt
@@ -1,0 +1,34 @@
+package com.suqi8.oshin.hook.android
+
+import android.media.AudioAttributes
+import android.media.AudioManager
+import com.highcapable.yukihookapi.hook.entity.YukiBaseHooker
+import com.highcapable.kavaref.KavaRef.Companion.resolve
+
+class IgnoreAudioFocus : YukiBaseHooker() {
+    override fun onHook() {
+        loadSystem {
+            if (prefs("android").getBoolean("IgnoreAudioFocus", false)) {
+                "com.android.server.audio.MediaFocusControl".toClass().resolve().apply {
+                    firstMethod {
+                        name = "requestAudioFocus"
+                    }.hook {
+                        before {
+                            val audioAttrs = args().first().cast<AudioAttributes>()
+                                ?: run {
+                                    return@before
+                                }
+                            val usage = audioAttrs.usage
+                            // 允许通话、辅助功能和导航提示
+                            if (usage != AudioAttributes.USAGE_VOICE_COMMUNICATION &&
+                                usage != AudioAttributes.USAGE_ASSISTANCE_ACCESSIBILITY &&
+                                usage != AudioAttributes.USAGE_ASSISTANCE_NAVIGATION_GUIDANCE) {
+                                result = AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/suqi8/oshin/hook/android/android.kt
+++ b/app/src/main/java/com/suqi8/oshin/hook/android/android.kt
@@ -9,6 +9,7 @@ class android : YukiBaseHooker() {
         loadApp(hooker = DisablePinVerifyPer72h())
         loadApp(hooker = AllowUntrustedTouch())
         loadHooker(PackageManagerServices())
+        loadHooker(IgnoreAudioFocus())
         //loadApp(hooker = Package_Installer())
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -258,6 +258,7 @@
     <string name="smart_accessibility_service">智能授权无障碍服务</string>
     <string name="whitelist_app_auto_authorization">开启后在白名单应用列表选中的应用程序将会自动授权，未选中的应用程序将会直接跳转至应用无障碍开关页面。</string>
     <string name="accessibility_whitelist">无障碍服务白名单</string>
+    <string name="ignore_audio_focus">忽略媒体音频焦点(允许多个应用同时发声)</string>
     <string name="remove_installation_frequency_popup">移除安装频繁弹窗</string>
     <string name="remove_attempt_installation_popup">移除尝试安装弹窗</string>
     <string name="remove_version_check">移除版本号检测</string>


### PR DESCRIPTION
![IMG_20260316_212832](https://github.com/user-attachments/assets/c786a49e-90b1-4409-9334-3d664dfb614c)
与小米的这个功能类似，oppo没有这个实现。启用后应用不会抢音频焦点，例如听歌的时候听语音消息不会被打断